### PR TITLE
Fix two out-of-bounds cache accesses causing device loss under dense caches (#4, #5)

### DIFF
--- a/include/SharcCommon.h
+++ b/include/SharcCommon.h
@@ -564,6 +564,12 @@ void SharcUpdateMiss(in SharcParameters sharcParameters, in SharcState sharcStat
     for (int i = 0; i < sharcState.pathLength; ++i)
     {
         HashGridIndex hashGridIndex = sharcState.cacheIndices[i];
+        // A full bucket makes HashGridInsertEntry return HASH_GRID_INVALID_CACHE_INDEX and SharcUpdateHit stores
+        // that sentinel into cacheIndices verbatim. It must be skipped before the responsive offset/mask block:
+        // masking it unconditionally rewrites it to SHARC_CACHE_INDEX_BIT_MASK, which is no longer INVALID, so
+        // SharcAddVoxelData's guard passes and the atomics land far past the end of the accumulation buffer
+        if (hashGridIndex == HASH_GRID_INVALID_CACHE_INDEX)
+            continue;
         bool isNewSample = false;
 #if SHARC_ENABLE_RESPONSIVE_LIGHTING
         if (isResponsiveLighting)
@@ -659,6 +665,9 @@ bool SharcUpdateHit(in SharcParameters sharcParameters, inout SharcState sharcSt
     for (i = 0; i < sharcState.pathLength; ++i)
     {
         HashGridIndex tempHashGridIndex = sharcState.cacheIndices[i];
+        // Skip full-bucket sentinels before the responsive offset/mask block — same reasoning as SharcUpdateMiss
+        if (tempHashGridIndex == HASH_GRID_INVALID_CACHE_INDEX)
+            continue;
         bool isNewSample = false;
 #if SHARC_ENABLE_RESPONSIVE_LIGHTING
         if (responsiveCacheIndex != HASH_GRID_INVALID_CACHE_INDEX)

--- a/include/SharcCommon.h
+++ b/include/SharcCommon.h
@@ -901,10 +901,13 @@ void SharcResolveEntry(uint entryIndex, SharcParameters sharcParameters, SharcRe
 
     // Performs hash map lookup to find existing entries in case previous insertions
     // encountered collisions and a different slot was assigned.
-    // Uses a fixed-size linear probe window
+    // Uses a fixed-size linear probe window, clamped to the table capacity: an application is allowed to
+    // allocate exactly `capacity` entries, so entries in the last window cannot blindly look forward —
+    // doing so reads past the end of the hash-entry and resolved buffers once those slots become occupied
     if (sampleNumPrev == 0)
     {
-        for (uint i = entryIndex + 1; i < entryIndex + 1 + SHARC_LINEAR_PROBE_WINDOW_SIZE; ++i)
+        uint probeEnd = min(entryIndex + 1 + SHARC_LINEAR_PROBE_WINDOW_SIZE, sharcParameters.hashGridData.capacity);
+        for (uint i = entryIndex + 1; i < probeEnd; ++i)
         {
             HashGridKey hashKeyOld = BUFFER_AT_OFFSET(sharcParameters.hashGridData.hashEntriesBuffer, i);
             if (hashKeyOld == hashGridKey)


### PR DESCRIPTION
Fixes #4, fixes #5 — two independent out-of-bounds accesses, both surfacing as
`VK_ERROR_DEVICE_LOST` once the hash table becomes dense (large sceneScale,
geometry-dense views).

- **#4** (`SharcUpdateHit`/`SharcUpdateMiss`): a full-bucket
  `HASH_GRID_INVALID_CACHE_INDEX` sentinel stored in `cacheIndices` is rewritten
  by the unconditional `& SHARC_CACHE_INDEX_BIT_MASK` into a forged in-range
  value, bypassing `SharcAddVoxelData`'s guard; the atomics then land
  ~2 GiB past the accumulation buffer. Fixed by skipping the sentinel before the
  responsive offset/mask block (a post-mask compare is insufficient — the
  responsive offset can shift the sentinel first). Verified against
  driver-reported fault addresses: the faulting page was exactly
  `accumulationBase + SHARC_CACHE_INDEX_BIT_MASK * 32` (SH layout), bit-identical
  across independent device losses.
- **#5** (`SharcResolveEntry`): the `sampleNumPrev == 0` recovery probe reads up
  to `SHARC_LINEAR_PROBE_WINDOW_SIZE` entries past `capacity` for entries in the
  last window. Fixed by clamping the probe end to the table capacity.

With both fixes our previously 100%-reproducing case (25k–100k instance dynamic
scene, sceneScale 100, capacity 2^22, Vulkan/GLSL path with
`SHARC_ENABLE_RESPONSIVE_LIGHTING=1` + `SHARC_ENABLE_SH_ENCODING=1`) runs
indefinitely without device loss.